### PR TITLE
test

### DIFF
--- a/tests/add.rs
+++ b/tests/add.rs
@@ -150,10 +150,7 @@ async fn prints_modified_manifest_for_dry_run() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn validate_add_from_path() -> Result<()> {
-    let project = Project::new("foo")?;
-
+fn validate_add_from_path(project: &Project) -> Result<()> {
     project
         .cargo_component("add --path foo/baz foo:baz")
         .assert()
@@ -167,6 +164,22 @@ fn validate_add_from_path() -> Result<()> {
     let manifest = fs::read_to_string(project.root().join("Cargo.toml"))?;
     assert!(contains(r#""foo:baz" = { path = "foo/baz" }"#).eval(&manifest));
     assert!(contains(r#""foo:qux" = { path = "foo/qux" }"#).eval(&manifest));
+    Ok(())
+}
 
+#[test]
+fn test_validate_add_from_path() -> Result<()> {
+    let project = Project::new("foo")?;
+    validate_add_from_path(&project)?;
+    Ok(())
+}
+
+#[test]
+fn two_projects_in_one_workspace_validate_add_from_path() -> Result<()> {
+    let root = create_root()?;
+    let foo = Project::with_root(&root, "foo", "")?;
+    let bar = Project::with_root(&root, "bar", "")?;
+    validate_add_from_path(&foo)?;
+    validate_add_from_path(&bar)?;
     Ok(())
 }


### PR DESCRIPTION
Also isolate each test run. Previously all tests were sharing the same target/tests/Cargo.toml, which each test was modifying. This made order in which tests run significant and difficult to debug. Add test `two_projects_in_one_workspace_validate_add_from_path` which cretes two projects in the same workspace to make sure we modify the current package's manifest.